### PR TITLE
Add debugger option to the CMakeList

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS )
 set(JERRY_LIBC    ON  CACHE BOOL "Build and use jerry-libc?")
 set(JERRY_LIBM    ON  CACHE BOOL "Build and use jerry-libm?")
 set(JERRY_CMDLINE ON  CACHE BOOL "Build jerry command line tool?")
+set(JERRY_DEBUGGER ON  CACHE BOOL "Build and use jerry-debugger?")
 set(UNITTESTS     OFF CACHE BOOL "Build unit tests?")
 
 # Optional build settings
@@ -35,6 +36,7 @@ set(ENABLE_LTO                ON                                    CACHE BOOL  
 set(ENABLE_ALL_IN_ONE         OFF                                   CACHE BOOL   "Enable all-in-one build?")
 set(ENABLE_STRIP              ON                                    CACHE BOOL   "Enable stripping all symbols from release binary?")
 set(ENABLE_STATIC_LINK        ON                                    CACHE BOOL   "Enable static linking?")
+set(BUILD_JERRY_DEBUGGER      ON                                    CACHE BOOL    "Enable jerry-debugger?")
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
@@ -55,6 +57,7 @@ message(STATUS "CMAKE_BUILD_TYPE          " ${CMAKE_BUILD_TYPE})
 message(STATUS "JERRY_LIBC                " ${JERRY_LIBC})
 message(STATUS "JERRY_LIBM                " ${JERRY_LIBM})
 message(STATUS "JERRY_CMDLINE             " ${JERRY_CMDLINE})
+message(STATUS "JERRY_DEBUGGER            " ${JERRY_DEBUGGER})
 message(STATUS "UNITTESTS                 " ${UNITTESTS})
 message(STATUS "PORT_DIR                  " ${PORT_DIR})
 message(STATUS "ENABLE_LTO                " ${ENABLE_LTO})

--- a/jerry-core/CMakeLists.txt
+++ b/jerry-core/CMakeLists.txt
@@ -48,6 +48,7 @@ message(STATUS "MEM_HEAP_SIZE_KB          " ${MEM_HEAP_SIZE_KB})
 # Include directories
 set(INCLUDE_CORE
     "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/debugger"
     "${CMAKE_CURRENT_SOURCE_DIR}/ecma/base"
     "${CMAKE_CURRENT_SOURCE_DIR}/ecma/builtin-objects"
     "${CMAKE_CURRENT_SOURCE_DIR}/ecma/operations"
@@ -62,6 +63,7 @@ set(INCLUDE_CORE
 # Sources
 # Jerry core
 file(GLOB SOURCE_CORE_API                   *.c)
+file(GLOB SOURCE_CORE_DEBUGGER              debugger/*.c)
 file(GLOB SOURCE_CORE_ECMA_BASE             ecma/base/*.c)
 file(GLOB SOURCE_CORE_ECMA_BUILTINS         ecma/builtin-objects/*.c)
 file(GLOB SOURCE_CORE_ECMA_OPERATIONS       ecma/operations/*.c)
@@ -75,6 +77,7 @@ file(GLOB SOURCE_CORE_VM                    vm/*.c)
 
 set(SOURCE_CORE_FILES
     ${SOURCE_CORE_API}
+    ${SOURCE_CORE_DEBUGGER}
     ${SOURCE_CORE_ECMA_BASE}
     ${SOURCE_CORE_ECMA_BUILTINS}
     ${SOURCE_CORE_ECMA_OPERATIONS}


### PR DESCRIPTION
Add JerryScript debugger option to the CMakeLists, in the root and the jerry-core folder . 
