### PR TITLE
Implement the source file name sender

### DIFF
--- a/jerry-core/jerry-api.h
+++ b/jerry-core/jerry-api.h
@@ -292,6 +292,13 @@ bool jerry_foreach_object_property (const jerry_value_t, jerry_object_property_f
 size_t jerry_parse_and_save_snapshot (const jerry_char_t *, size_t, bool, bool, uint8_t *, size_t);
 jerry_value_t jerry_exec_snapshot (const void *, size_t, bool);
 
+#ifdef JERRY_DEBUGGER
+/**
+ * Debugger functions
+ */
+void jerry_debug_send_source_file_name (const jerry_char_t *, size_t);
+#endif /* JERRY_DEBUGGER */
+
 /**
  * @}
  */

--- a/jerry-main/main-unix.c
+++ b/jerry-main/main-unix.c
@@ -23,6 +23,10 @@
 #include "jerry-port.h"
 #include "jerry-port-default.h"
 
+#ifdef JERRY_DEBUGGER
+#include "jerry-debugger.h"
+#endif /* JERRY_DEBUGGER */
+
 /**
  * Maximum command line arguments number
  */
@@ -547,6 +551,13 @@ main (int argc,
     {
       size_t source_size;
       const jerry_char_t *source_p = read_file (file_names[i], &source_size);
+
+      /**
+       * Send the source file name to the client
+       */
+#ifdef JERRY_DEBUGGER
+      jerry_debug_send_source_file_name ((jerry_char_t *) file_names[i], strlen (file_names[i]));
+#endif /* JERRY_DEBUGGER */
 
       if (source_p == NULL)
       {


### PR DESCRIPTION
Add the function, which can be send the source file name to the client. 

- Correct some style issue
- Add general string sender method ( function name sender can be use it in the near future )


 JerryScript-DCO-1.0-Signed-off-by: Levente Orban orbanl@inf.u-szeged.hu