### PR TITLE
Implement the function byte code sender

### DIFF
--- a/jerry-core/debugger/jerry-debugger.h
+++ b/jerry-core/debugger/jerry-debugger.h
@@ -17,7 +17,7 @@
 #define JERRY_DEBUGGER_H
 
 #include "jmem-allocator.h"
-#include <stdint.h>
+#include "ecma-globals.h"
 
 #define MAX_BUFFER_SIZE 64
 
@@ -43,6 +43,12 @@ extern bool jerry_debugger_send (size_t data_len);
  ((MAX_BUFFER_SIZE - sizeof (jerry_debugger_message_header_t)) / sizeof (type))
 
 /**
+ * Type cast the debugger buffer into a specific type.
+ */
+#define JERRY_DEBUGGER_MESSAGE(type, name_p) \
+  type *name_p = ((type *) &jerry_debugger_buffer)
+
+/**
  * Types for the package
  *
  * This helps the debugger to decide what type of the data come
@@ -52,16 +58,15 @@ extern bool jerry_debugger_send (size_t data_len);
  */
 typedef enum
 {
-  JERRY_DEBUGGER_BREAKPOINT_LIST = 1,                 /**< there is more piece of the breakpoint list */
-  JERRY_DEBUGGER_BREAKPOINT_LIST_END = 2,             /**< the last piece of the breakpoint list
+  JERRY_DEBUGGER_PARSE_ERROR = 1,                     /**< parse error */
+  JERRY_DEBUGGER_BYTE_CODE_CPTR = 2,                  /**< byte code compressed pointer */
+  JERRY_DEBUGGER_PARSE_FUNCTION = 3,                  /**< parsing a new function */
+  JERRY_DEBUGGER_BREAKPOINT_LIST = 4,                 /**< there is more piece of the breakpoint list */
+  JERRY_DEBUGGER_BREAKPOINT_LIST_END = 5,             /**< the last piece of the breakpoint list
                                                        *   or when one buffer send is enough for the engine */
-  JERRY_DEBUGGER_FUNCTION_NAME = 3,                   /**< there is more piece of the function name */
-  JERRY_DEBUGGER_FUNCTION_NAME_END = 4,               /**< the last piece of the function name
-                                                       *   or when one buffer send is enough for the engine */
-  JERRY_DEBUGGER_SOURCE_FILE_NAME = 5,                /**< there is more piece of the source file name */
-  JERRY_DEBUGGER_SOURCE_FILE_NAME_END = 6,            /**< if we send the last piece of the source file name
-                                                       *   or when one buffer send is enough for the engine  */
-  JERRY_DEBUGGER_UNIQUE_START_BYTE_CODE_CPTR = 7,     /**< byte code starter compressed pointer */
+  JERRY_DEBUGGER_SOURCE_FILE_NAME = 6,                /**< source file name fragment */
+  JERRY_DEBUGGER_FUNCTION_NAME = 7,                   /**< function name fragment */
+  JERRY_DEBUGGER_FREE_BYTE_CODE_CPTR = 8,             /**< invalidate byte code compressed pointer */
 } jerry_debugger_header_type_t;
 
 /**
@@ -88,7 +93,7 @@ typedef struct
 typedef struct
 {
   jerry_debugger_message_header_t header; /**< header of the struct */
-  jmem_cpointer_t byte_code_cp; /**< the byte code compressed pointer */
+  uint8_t byte_code_cp[sizeof (jmem_cpointer_t)]; /**< the byte code compressed pointer */
 } jerry_debugger_byte_code_cptr_t;
 
 /**
@@ -110,9 +115,9 @@ typedef struct
   jerry_debugger_bp_pairs_t breakpoint_pairs[JERRY_DEBUGGER_MAX_SIZE (jerry_debugger_bp_pairs_t)];
 } jerry_debugger_breakpoint_list_t;
 
-/**
- * Type cast the debugger buffer into a specific type.
- */
-#define JERRY_DEBUGGER_BUFFER_AS(type) ((type *) &jerry_debugger_buffer)
+extern void jerry_debugger_send_type (jerry_debugger_header_type_t type);
+extern void jerry_debugger_send_function_name (const jerry_char_t *function_name_p, size_t function_name_length);
+extern void jerry_debugger_send_function_cp (jerry_debugger_header_type_t type, ecma_compiled_code_t *compiled_code_p);
+extern void jerry_debugger_send_source_file_name (const jerry_char_t *file_name_p, size_t file_name_length);
 
 #endif /* JERRY_DEBUGGER_H */

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -24,6 +24,11 @@
 #include "byte-code.h"
 #include "re-compiler.h"
 
+#ifdef JERRY_DEBUGGER
+#include "jcontext.h"
+#include "jerry-debugger.h"
+#endif /*JERRY_DEBUGGER */
+
 /** \addtogroup ecma ECMA
  * @{
  *
@@ -1430,6 +1435,13 @@ ecma_bytecode_deref (ecma_compiled_code_t *bytecode_p) /**< byte code pointer */
 
   if (bytecode_p->status_flags & CBC_CODE_FLAGS_FUNCTION)
   {
+#ifdef JERRY_DEBUGGER
+    if (JERRY_CONTEXT (jerry_init_flags) & JERRY_INIT_DEBUGGER)
+    {
+      jerry_debugger_send_function_cp (JERRY_DEBUGGER_FREE_BYTE_CODE_CPTR, bytecode_p);
+    }
+#endif /* JERRY_DEBUGGER */
+
     jmem_cpointer_t *literal_start_p = NULL;
     uint32_t literal_end;
     uint32_t const_literal_end;

--- a/jerry-core/jerry-api.h
+++ b/jerry-core/jerry-api.h
@@ -297,7 +297,6 @@ jerry_value_t jerry_exec_snapshot (const void *, size_t, bool);
  * Debugger functions
  */
 void jerry_debug_send_source_file_name (const jerry_char_t *, size_t);
-void jerry_debug_send_function_name (const jerry_char_t *, size_t);
 #endif /* JERRY_DEBUGGER */
 
 /**

--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -17,8 +17,10 @@
 #include "js-parser-internal.h"
 
 #ifdef JERRY_DEBUGGER
- #include "jcontext.h"
-#endif /* JERRY_DEBUGGER */
+#include "jcontext.h"
+#include "jerry-debugger.h"
+#endif /*JERRY_DEBUGGER */
+
 /** \addtogroup parser Parser
  * @{
  *
@@ -400,8 +402,8 @@ parser_parse_function_statement (parser_context_t *context_p) /**< context */
 #ifdef JERRY_DEBUGGER
   if (JERRY_CONTEXT (jerry_init_flags) & JERRY_INIT_DEBUGGER)
   {
-    jerry_debug_send_function_name ((jerry_char_t *) name_p->u.char_p,
-                                    name_p->prop.length);
+    jerry_debugger_send_function_name ((jerry_char_t *) name_p->u.char_p,
+                                       name_p->prop.length);
   }
 #endif /* JERRY_DEBUGGER */
 

--- a/jerry-main/main-unix.c
+++ b/jerry-main/main-unix.c
@@ -556,7 +556,7 @@ main (int argc,
        * Send the source file name to the client
        */
 #ifdef JERRY_DEBUGGER
-      jerry_debug_send_source_file_name ((jerry_char_t *) file_names[i], strlen (file_names[i]));
+      jerry_debugger_send_source_file_name ((jerry_char_t *) file_names[i], strlen (file_names[i]));
 #endif /* JERRY_DEBUGGER */
 
       if (source_p == NULL)


### PR DESCRIPTION
- Add `jerry_debug_send_type` function, which send the type of the message to client
- Add `jerry_debug_send_function_cp` function which send the compressed byte code to client
- Restructure the message type numbers, and add the `PARSE_ERROR`, `BYTE_CODE_CPTR`, and  `FREE_BYTE_CODE_CPTR` types
- Move the `jerry_debug_send_function_name` method to jerry-debugger.c file 
- Upgrade the python script 

JerryScript-DCO-1.0-Signed-off-by: Levente Orban orbanl@inf.u-szeged.hu